### PR TITLE
PHP identifiers cannot contain '-'

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -8,22 +8,23 @@ Author: Iain Matchett
 
 */
 // No direct call
-//if( !defined( 'YOURLS_ABSPATH' ) ) die(); 
-define( 'OG-IMAGE', "" );
-define( 'OG-TITLE', "" );
-define( 'OG-target', "" );
-define( 'OG-SITENAME', "" );
+if( !defined( 'YOURLS_ABSPATH' ) ) die(); 
 
-yourls_add_action( 'pre_redirect', 'og-everywhere' );
-function og-everywhere( $args )
+define( 'OG_IMAGE', "" );
+define( 'OG_TITLE', "" );
+define( 'OG_target', "" );
+define( 'OG_SITENAME', "" );
+
+yourls_add_action( 'pre_redirect', 'matchett_og_everywhere' );
+function matchett_og_everywhere( $args )
 {
-    if(strpos($location, $OG-target) !== false )
+    if(strpos($location, $OG_target) !== false )
     {
-        echo '<meta property="og:title" content="' . $OG-TITLE .'" />
+        echo '<meta property="og:title" content="' . $OG_TITLE .'" />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="' . $location . '" />
-        <meta property="og:image" content="' . $OG-IMAGE . '" />
-        <meta property="og:site_name" content="' . $OG-SITENAME . '" />';
+        <meta property="og:image" content="' . $OG_IMAGE . '" />
+        <meta property="og:site_name" content="' . $OG_SITENAME . '" />';
     }
     
     


### PR DESCRIPTION
Also: Prefixed the function name to reduce conflict risk.

Also: Restored "no direct call" guard.